### PR TITLE
Build Error Fix 

### DIFF
--- a/fingerprint/BiometricsFingerprint.cpp
+++ b/fingerprint/BiometricsFingerprint.cpp
@@ -473,6 +473,14 @@ Return<void> BiometricsFingerprint::onFingerUp() {
     return Void();
 }
 
+Return<void> BiometricsFingerprint::onShowUdfpsOverlay() {
+    return Void();
+}
+
+Return<void> BiometricsFingerprint::onHideUdfpsOverlay() {
+    return Void();
+}
+    
 }  // namespace implementation
 }  // namespace V2_3
 }  // namespace fingerprint

--- a/fingerprint/BiometricsFingerprint.h
+++ b/fingerprint/BiometricsFingerprint.h
@@ -70,7 +70,8 @@ struct BiometricsFingerprint : public IBiometricsFingerprint, public IXiaomiFing
     Return<RequestStatus> remove(uint32_t gid, uint32_t fid) override;
     Return<RequestStatus> setActiveGroup(uint32_t gid, const hidl_string& storePath) override;
     Return<RequestStatus> authenticate(uint64_t operationId, uint32_t gid) override;
-
+    Return<void> onShowUdfpsOverlay() override;
+    Return<void> onHideUdfpsOverlay() override;
     Return<int32_t> extCmd(int32_t cmd, int32_t param) override;
 
     static fingerprint_device_t* openHal();


### PR DESCRIPTION
device/xiaomi/raphael/fingerprint/BiometricsFingerprint.cpp:209:25: error: allocating an object of abstract class type 'android::hardware::biometrics::fingerprint::V2_3::implementation::BiometricsFingerprint'
        sInstance = new BiometricsFingerprint();
                        ^
out/soong/.intermediates/hardware/interfaces/biometrics/fingerprint/2.3/android.hardware.biometrics.fingerprint@2.3_genc++_headers/gen/android/hardware/biometrics/fingerprint/2.3/IBiometricsFingerprint.h:214:47: note: unimplemented pure virtual method 'onShowUdfpsOverlay' in 'BiometricsFingerprint'
    virtual ::android::hardware::Return<void> onShowUdfpsOverlay() = 0;
                                              ^
out/soong/.intermediates/hardware/interfaces/biometrics/fingerprint/2.3/android.hardware.biometrics.fingerprint@2.3_genc++_headers/gen/android/hardware/biometrics/fingerprint/2.3/IBiometricsFingerprint.h:219:47: note: unimplemented pure virtual method 'onHideUdfpsOverlay' in 'BiometricsFingerprint'
    virtual ::android::hardware::Return<void> onHideUdfpsOverlay() = 0;